### PR TITLE
Fix issue #16: deploy image on port 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
-EXPOSE 3000
+EXPOSE 80
 
-ENV PORT=3000
+ENV PORT=80
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/config/next-config-js/output


### PR DESCRIPTION
# Issue

This closes #16 

# Description

Use port 80 for docker image
