### PR TITLE
Add API call wrapper method

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,10 +8,9 @@ import {
   FormGroup,
   TextField,
 } from "@mui/material";
-import { AxiosError } from "axios";
 import { FormEvent, ReactElement } from "react";
 
-import { api } from "@/lib";
+import { apiPost } from "@/lib";
 
 export default function LoginPage(): ReactElement {
   async function onSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
@@ -23,23 +22,29 @@ export default function LoginPage(): ReactElement {
     const password = formData.get("password") as string;
 
     // Login directly with the API - the creds never reach the frontend server
-    await api
-      .post("/login", {
+    await apiPost(
+      "/login",
+      {
         username: username,
         password: password,
-      })
-      .catch((error: AxiosError) => {
-        // Non-200 status codes are thrown as errors
-        if (error.status == 401) {
-          alert("Invalid username or password");
-          return;
-        } else {
-          alert("An error occurred (" + error.status + ")");
-        }
-      });
+      },
+      {
+        // Special handling of 401s for login
+        redirect401: false,
+        errorCallback: (error) => {
+          // Non-200 status codes are thrown as errors
+          if (error.status == 401) {
+            alert("Invalid username or password");
+            return;
+          } else {
+            alert("An error occurred (" + error.status + ")");
+          }
+        },
+      },
+    );
 
-    // Redirect to the home page
-    window.location.href = "/";
+    // Go back to the previous page
+    history.back();
   }
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,13 +2,11 @@ import { Grid2 } from "@mui/material";
 import { type ReactElement } from "react";
 
 import { RecipeCard } from "@/components";
-import { api } from "@/lib";
+import { apiGet } from "@/lib";
 import { type Recipe } from "@/lib/types";
 
 export default async function Home(): Promise<ReactElement> {
-  const recipes = await api
-    .get<Recipe[]>("/recipes")
-    .then((response) => response.data);
+  const recipes = await apiGet<Recipe[]>("/recipes");
 
   return (
     <Grid2 container columns={{ xs: 4, sm: 8, md: 12 }} spacing={3}>

--- a/src/app/recettes/[recipeId]/page.tsx
+++ b/src/app/recettes/[recipeId]/page.tsx
@@ -19,7 +19,7 @@ import Image from "next/image";
 import { ReactElement } from "react";
 
 import { RecipeCard } from "@/components";
-import { api, capitalizeFirstLetter } from "@/lib";
+import { apiGet, capitalizeFirstLetter } from "@/lib";
 import { Recipe } from "@/lib/types";
 
 type RecipePageProps = {
@@ -32,15 +32,9 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const { recipeId } = await params;
 
-  let recipe: Recipe;
-  try {
-    recipe = await api
-      .get<Recipe>(`/recipes/${recipeId}`)
-      .then((response) => response.data);
-  } catch (error) {
-    console.error(error);
-    return {}; // If error, don't change metadata
-  }
+  const recipe = await apiGet<Recipe>(`/recipes/${recipeId}`, {
+    defaultResult: {},
+  });
 
   const globalTitle = (await parent).title?.absolute;
 
@@ -70,20 +64,14 @@ export default async function RecipePage({
 }: RecipePageProps): Promise<ReactElement> {
   const { recipeId } = await params;
 
-  let recipe: Recipe;
-  try {
-    recipe = await api
-      .get<Recipe>(`/recipes/${recipeId}`)
-      .then((response) => response.data);
-  } catch (error) {
-    console.error(error);
+  const recipe = await apiGet<Recipe | null>(`/recipes/${recipeId}`, {
+    defaultResult: null,
+  });
+  if (recipe == null) {
     return <i>An error occured. Please try again later</i>;
   }
 
-  const relatedRecipes = await api
-    .get<Recipe[]>(`/recipes/${recipeId}/related`)
-    .then((response) => response.data)
-    .catch(() => []);
+  const relatedRecipes = await apiGet<Recipe[]>(`/recipes/${recipeId}/related`);
   const hasRelated = relatedRecipes.length > 0;
 
   const {

--- a/src/components/loginButton.tsx
+++ b/src/components/loginButton.tsx
@@ -5,14 +5,13 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ReactElement, useEffect, useState } from "react";
 
-import { api } from "@/lib";
+import { apiGet } from "@/lib";
 
 async function checkLogin(): Promise<boolean> {
-  return await api
-    .get("/me")
-    .then((response) => response.status == 200)
-    .catch(() => false)
-    .finally(() => false);
+  return !!(await apiGet<boolean>("/me", {
+    redirect401: false,
+    defaultResult: false,
+  }));
 }
 
 export function LoginButton(): ReactElement {
@@ -36,12 +35,10 @@ export function LoginButton(): ReactElement {
         Notably this means we pull the HTML for the prof's frontpage on each logout (couple kB of data).
         But as it is not rendered this is not too big a deal. If we had control over the API and could prevent this 302 response we could avoid this.
     */
-    await api
-      .get("/logout", { headers: { Accept: "*/*" } })
-      .catch(() => {
-        console.error("Failed to logout");
-      })
-      .finally(() => setIsLoggedIn(false));
+    await apiGet<void>("/logout", {
+      axiosConfig: { headers: { Accept: "*/*" } },
+    });
+    setIsLoggedIn(false);
   }
 
   if (isLoggedIn) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8,16 +8,26 @@ export const api = Axios.create({
   headers: { Accept: "application/json, application/xml" },
 });
 
+interface apiCallOptions<T> {
+  axiosConfig?: object;
+  redirect401?: boolean;
+  defaultResult?: T;
+  errorCallback?: (error: AxiosError) => void | T;
+}
+
 export async function apiGet<T>(
   url: string,
-  config: object = {}, // Default: empty object - usually used for query params
-  redirect401: boolean = true, // Default: true - redirect to login page in case of 401
-  defaultResult: T = <T>null, // Default: null
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  errorCallback: (error: AxiosError) => void = (_error) => {}, // Default: do nothing
+  // Very cursed syntax, but see https://stackoverflow.com/questions/23314806/setting-default-value-for-typescript-object-passed-as-argument
+  {
+    axiosConfig = {}, // Default: empty object - usually used for query params
+    redirect401 = true, // Default: true - redirect to login page in case of 401
+    defaultResult = <T>null, // Default: null
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    errorCallback = (_error) => {}, // Default: do nothing
+  }: apiCallOptions<T> = {},
 ): Promise<T> {
   return api
-    .get<T>(url, config)
+    .get<T>(url, axiosConfig)
     .then((response) => response.data)
     .catch((error) => {
       // "Usual" callback in case of expired token
@@ -34,14 +44,16 @@ export async function apiGet<T>(
 export async function apiPost<T>(
   url: string,
   data: object, // No default, usually for a post we will want a body
-  config: object = {}, // Default: empty object - usually used for query params
-  redirect401: boolean = true, // Default: true - redirect to login page in case of 401
-  defaultResult: T = <T>null, // Default: null
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  errorCallback: (error: AxiosError) => void = (_error) => {}, // Default: do nothing
+  {
+    axiosConfig = {},
+    redirect401 = true, // Default: true - redirect to login page in case of 401
+    defaultResult = <T>null, // Default: null
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    errorCallback = (_error) => {}, // Default: empty object - usually used for query params
+  }: apiCallOptions<T> = {},
 ): Promise<T> {
   return api
-    .post<T>(url, data, config)
+    .post<T>(url, data, axiosConfig)
     .then((response) => response.data)
     .catch((error) => {
       // "Usual" callback in case of expired token

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
-import Axios from "axios";
+import Axios, { AxiosError } from "axios";
+import { redirect } from "next/navigation";
 
 export const api = Axios.create({
   baseURL: "https://gourmet.cours.quimerch.com",
@@ -6,3 +7,50 @@ export const api = Axios.create({
   withCredentials: true,
   headers: { Accept: "application/json, application/xml" },
 });
+
+export async function apiGet<T>(
+  url: string,
+  config: object = {}, // Default: empty object - usually used for query params
+  redirect401: boolean = true, // Default: true - redirect to login page in case of 401
+  defaultResult: T = <T>null, // Default: null
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  errorCallback: (error: AxiosError) => void = (_error) => {}, // Default: do nothing
+): Promise<T> {
+  return api
+    .get<T>(url, config)
+    .then((response) => response.data)
+    .catch((error) => {
+      // "Usual" callback in case of expired token
+      if (redirect401 && error.response.status == 401) {
+        redirect("/login");
+      }
+
+      // Custom callback in other cases
+      errorCallback(error);
+      return defaultResult;
+    });
+}
+
+export async function apiPost<T>(
+  url: string,
+  data: object, // No default, usually for a post we will want a body
+  config: object = {}, // Default: empty object - usually used for query params
+  redirect401: boolean = true, // Default: true - redirect to login page in case of 401
+  defaultResult: T = <T>null, // Default: null
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  errorCallback: (error: AxiosError) => void = (_error) => {}, // Default: do nothing
+): Promise<T> {
+  return api
+    .post<T>(url, data, config)
+    .then((response) => response.data)
+    .catch((error) => {
+      // "Usual" callback in case of expired token
+      if (redirect401 && error.response.status == 401) {
+        redirect("/login");
+      }
+
+      // Custom callback in other cases
+      errorCallback(error);
+      return defaultResult;
+    });
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -36,9 +36,11 @@ export async function apiGet<T>(
       }
 
       // Custom callback in other cases
-      errorCallback(error);
-      return defaultResult;
-    });
+      console.error(error);
+      const callbackResult = errorCallback(error);
+      return callbackResult || defaultResult;
+    })
+    .finally(() => defaultResult);
 }
 
 export async function apiPost<T>(
@@ -61,8 +63,10 @@ export async function apiPost<T>(
         redirect("/login");
       }
 
+      console.error(error);
       // Custom callback in other cases
-      errorCallback(error);
-      return defaultResult;
-    });
+      const callbackResult = errorCallback(error);
+      return callbackResult || defaultResult;
+    })
+    .finally(() => defaultResult);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,10 +33,12 @@ export async function apiGet<T>(
       // "Usual" callback in case of expired token
       if (redirect401 && error.response.status == 401) {
         redirect("/login");
+      } else {
+        // TODO: This does not work; use an interceptor instead
+        console.error(error);
       }
 
       // Custom callback in other cases
-      console.error(error);
       const callbackResult = errorCallback(error);
       return callbackResult || defaultResult;
     })
@@ -61,9 +63,10 @@ export async function apiPost<T>(
       // "Usual" callback in case of expired token
       if (redirect401 && error.response.status == 401) {
         redirect("/login");
+      } else {
+        console.error(error);
       }
 
-      console.error(error);
       // Custom callback in other cases
       const callbackResult = errorCallback(error);
       return callbackResult || defaultResult;


### PR DESCRIPTION
# Issue

This closes #25
_(The issue will be automatically closed if merged)_

# Description

Create two new methods for easily making GET and POST requests to the API, handling 401s and errors in a flexible way

# How to test

- Launch the app `npm run dev`
- ...

# Other notes
