### PR TITLE
Fix issue #41: have a fallback if image url is broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write --no-error-on-unmatched-pattern ./src ./app ./pages ./components ./lib",
-    "test": "jest"
+    "test": "jest",
+    "update-snapshot": "jest --updateSnapshot"
   },
   "dependencies": {
     "@emotion/cache": "^11.14.0",

--- a/src/app/recettes/[recipeId]/page.tsx
+++ b/src/app/recettes/[recipeId]/page.tsx
@@ -16,10 +16,9 @@ import {
   Typography,
 } from "@mui/material";
 import { Metadata, ResolvingMetadata } from "next";
-import Image from "next/image";
 import { ReactElement } from "react";
 
-import { RecipeCard } from "@/components";
+import { ImageWithFallback, RecipeCard } from "@/components";
 import { apiGet, capitalizeFirstLetter, parseInstructions } from "@/lib";
 import { Recipe } from "@/lib/types";
 
@@ -108,13 +107,14 @@ export default async function RecipePage({
                     aspectRatio: "16 / 9",
                   }}
                 >
-                  <Image
+                  <ImageWithFallback
                     src={image_url}
                     alt={name ?? "An image of the dish"}
                     fill
                     sizes="(max-width: 600px) 100vw, (max-width: 900px) 67vw, 50vw"
                     style={{ objectFit: "contain" }}
                     priority
+                    hideIfNoImage
                   />
                 </CardMedia>
               </Card>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,11 +12,11 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, type ReactElement } from "react";
 
+import { ImageWithFallback } from "./ImageWithFallback";
 import { LoginButton } from "./loginButton";
 
 export function Header(): ReactElement {
@@ -66,7 +66,7 @@ export function Header(): ReactElement {
         }}
       >
         {/* Logo and site name, centered inside the whole nav */}
-        <Image src="/logo.webp" alt="Logo" width={60} height={60} />
+        <ImageWithFallback src="/logo.webp" alt="Logo" width={60} height={60} />
         <Typography variant="h5">Sigma cooking</Typography>
 
         {/* Navigation */}

--- a/src/components/ImageWithFallback.tsx
+++ b/src/components/ImageWithFallback.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Image, { ImageProps } from "next/image";
+import { ReactElement, useState } from "react";
+
+type ImageWithFallbackProps = Omit<ImageProps, "onError" | "src"> & {
+  src?: string;
+  hideIfNoImage?: boolean;
+};
+
+export function ImageWithFallback({
+  src,
+  hideIfNoImage = false,
+  ...props
+}: ImageWithFallbackProps): ReactElement {
+  const [imgSrc, setImgSrc] = useState(src || "/defaultDishImage.webp");
+
+  if (hideIfNoImage && imgSrc === "/defaultDishImage.webp")
+    return <i>Image seems broken at the moment. Please retry later.</i>;
+
+  return (
+    <Image
+      {...props}
+      src={imgSrc}
+      onError={() => setImgSrc("/defaultDishImage.webp")}
+    />
+  );
+}

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,9 +1,10 @@
 import { Card, CardContent, CardMedia, Typography } from "@mui/material";
-import Image from "next/image";
 import Link from "next/link";
 import { ReactElement } from "react";
 
 import { Recipe } from "@/lib/types";
+
+import { ImageWithFallback } from "./ImageWithFallback";
 
 type RecipeCardProps = {
   recipe: Recipe;
@@ -41,8 +42,8 @@ export function RecipeCard({
       <CardMedia
         sx={{ position: "relative", width: "100%", aspectRatio: "4 / 3" }}
       >
-        <Image
-          src={image_url || "/defaultDishImage.webp"}
+        <ImageWithFallback
+          src={image_url}
           alt={name ?? "An image of the dish"}
           fill
           sizes={imageSizes}

--- a/src/components/__snapshots__/RecipeCard.test.tsx.snap
+++ b/src/components/__snapshots__/RecipeCard.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`RecipeCard renders the correct styles for hover state 1`] = `
         decoding="async"
         loading="lazy"
         sizes="100vw"
-        src="/_next/image?url=%2FtestImage.webp&w=3840&q=75"
+        src="http://localhost/_next/image?url=%2FtestImage.webp&w=3840&q=75"
         srcset="/_next/image?url=%2FtestImage.webp&w=640&q=75 640w, /_next/image?url=%2FtestImage.webp&w=750&q=75 750w, /_next/image?url=%2FtestImage.webp&w=828&q=75 828w, /_next/image?url=%2FtestImage.webp&w=1080&q=75 1080w, /_next/image?url=%2FtestImage.webp&w=1200&q=75 1200w, /_next/image?url=%2FtestImage.webp&w=1920&q=75 1920w, /_next/image?url=%2FtestImage.webp&w=2048&q=75 2048w, /_next/image?url=%2FtestImage.webp&w=3840&q=75 3840w"
         style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; object-fit: cover; color: transparent;"
       />

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
+export * from "./ImageWithFallback";
 export * from "./Header";
 export * from "./RecipeCard";


### PR DESCRIPTION
# Issue

This closes #41 
_(The issue will be automatically closed if merged)_

# Description

Create a component to handle images, have a fallback even if URL is here but broken

# How to test

- Launch the app `npm run dev`
- Check that it works
- If you really want to test (like I did) change so URL to a broken URL directly in the code
